### PR TITLE
Add extensible UVM CHI verification framework skeleton

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,44 @@
-# hello-world
+# UVM CHI Verification Skeleton
+
+这是一个可扩展的 UVM 验证框架示例，用于覆盖 CHI 协议验证中的核心能力（激励、监测、检查、覆盖率与场景组织）。
+
+## 目录结构
+
+- `uvm_chi/tb/chi_if.sv`：简化版 CHI 信号接口
+- `uvm_chi/agent/*`：transaction / sequencer / driver / monitor / agent
+- `uvm_chi/env/*`：scoreboard + functional coverage + env
+- `uvm_chi/seq/chi_basic_seq.sv`：基础随机 + corner 场景序列
+- `uvm_chi/tb/chi_test.sv`：base test + full function test
+- `uvm_chi/tb/top.sv`：仿真顶层
+
+## 当前已实现的“全功能验证”骨架能力
+
+1. **事务级建模**：CHI transaction 字段、约束、随机延迟。
+2. **主动激励**：driver 按 valid/ready 握手发包。
+3. **被动观测**：monitor 在握手成功时抓取事务。
+4. **一致性检查**：scoreboard 对地址对齐/QoS/路由场景做检查。
+5. **功能覆盖**：opcode/txn_type/qos/resp 以及关键 cross coverage。
+6. **场景编排**：基础随机与 corner case 联合运行。
+
+## 如何扩展到项目级“CHI 全协议验证”
+
+- 增加 CHI 五通道（REQ/RSP/SNP/DAT/CRD）的独立 agent 与时序关系检查。
+- 引入 reference model（目录一致性、缓存状态迁移、原子/屏障语义）。
+- 增加 protocol checker（ACE/CHI ordering, hazard, QoS fairness, retry/timeout）。
+- 增加 error injection（ECC/parity, poisoned data, malformed packet）。
+- 建立覆盖率收敛策略：feature coverage + scenario coverage + assertion coverage。
+
+## 运行示例（按你的仿真器调整）
+
+```bash
+# 以 VCS 为例（示意）
+vcs -sverilog -ntb_opts uvm \
+  uvm_chi/tb/chi_if.sv \
+  uvm_chi/tb/chi_pkg.sv \
+  uvm_chi/tb/top.sv \
+  -o simv
+
+./simv +UVM_TESTNAME=chi_full_func_test
+```
+
+> 说明：该仓库提供的是“可直接扩展的完整框架代码”，便于你快速落地 CHI 全功能验证平台。

--- a/uvm_chi/agent/chi_agent.sv
+++ b/uvm_chi/agent/chi_agent.sv
@@ -1,0 +1,32 @@
+class chi_agent extends uvm_component;
+  `uvm_component_utils(chi_agent)
+
+  chi_sequencer sqr;
+  chi_driver    drv;
+  chi_monitor   mon;
+  uvm_active_passive_enum is_active = UVM_ACTIVE;
+
+  function new(string name = "chi_agent", uvm_component parent = null);
+    super.new(name, parent);
+  endfunction
+
+  function void build_phase(uvm_phase phase);
+    super.build_phase(phase);
+    if (!uvm_config_db#(uvm_active_passive_enum)::get(this, "", "is_active", is_active)) begin
+      is_active = UVM_ACTIVE;
+    end
+
+    mon = chi_monitor::type_id::create("mon", this);
+    if (is_active == UVM_ACTIVE) begin
+      sqr = chi_sequencer::type_id::create("sqr", this);
+      drv = chi_driver::type_id::create("drv", this);
+    end
+  endfunction
+
+  function void connect_phase(uvm_phase phase);
+    super.connect_phase(phase);
+    if (is_active == UVM_ACTIVE) begin
+      drv.seq_item_port.connect(sqr.seq_item_export);
+    end
+  endfunction
+endclass

--- a/uvm_chi/agent/chi_driver.sv
+++ b/uvm_chi/agent/chi_driver.sv
@@ -1,0 +1,57 @@
+class chi_driver extends uvm_driver #(chi_item);
+  `uvm_component_utils(chi_driver)
+
+  virtual chi_if vif;
+
+  function new(string name = "chi_driver", uvm_component parent = null);
+    super.new(name, parent);
+  endfunction
+
+  function void build_phase(uvm_phase phase);
+    super.build_phase(phase);
+    if (!uvm_config_db#(virtual chi_if)::get(this, "", "vif", vif)) begin
+      `uvm_fatal(get_type_name(), "Cannot get chi_if vif from config_db")
+    end
+  endfunction
+
+  task run_phase(uvm_phase phase);
+    chi_item req;
+    reset_signals();
+    forever begin
+      seq_item_port.get_next_item(req);
+      drive_item(req);
+      seq_item_port.item_done();
+    end
+  endtask
+
+  task reset_signals();
+    vif.valid    <= 0;
+    vif.opcode   <= '0;
+    vif.txn_type <= '0;
+    vif.addr     <= '0;
+    vif.data     <= '0;
+    vif.src_id   <= '0;
+    vif.tgt_id   <= '0;
+    vif.qos      <= '0;
+    vif.resp     <= '0;
+    wait(vif.rst_n === 1'b1);
+  endtask
+
+  task drive_item(chi_item req);
+    repeat(req.delay_cycles) @(posedge vif.clk);
+
+    @(posedge vif.clk);
+    vif.valid    <= 1'b1;
+    vif.opcode   <= req.opcode;
+    vif.txn_type <= req.txn_type;
+    vif.addr     <= req.addr;
+    vif.data     <= req.data;
+    vif.src_id   <= req.src_id;
+    vif.tgt_id   <= req.tgt_id;
+    vif.qos      <= req.qos;
+    vif.resp     <= req.resp;
+
+    do @(posedge vif.clk); while (!vif.ready);
+    vif.valid <= 1'b0;
+  endtask
+endclass

--- a/uvm_chi/agent/chi_item.sv
+++ b/uvm_chi/agent/chi_item.sv
@@ -1,0 +1,31 @@
+class chi_item extends uvm_sequence_item;
+  rand bit [7:0]   opcode;
+  rand bit [3:0]   txn_type;
+  rand bit [47:0]  addr;
+  rand bit [255:0] data;
+  rand bit [15:0]  src_id;
+  rand bit [15:0]  tgt_id;
+  rand bit [7:0]   qos;
+  rand bit [3:0]   resp;
+  rand int unsigned delay_cycles;
+
+  constraint c_addr_align { addr[5:0] == 0; }
+  constraint c_qos        { qos inside {[0:15]}; }
+  constraint c_delay      { delay_cycles inside {[0:20]}; }
+
+  `uvm_object_utils_begin(chi_item)
+    `uvm_field_int(opcode, UVM_ALL_ON)
+    `uvm_field_int(txn_type, UVM_ALL_ON)
+    `uvm_field_int(addr, UVM_ALL_ON)
+    `uvm_field_int(data, UVM_ALL_ON)
+    `uvm_field_int(src_id, UVM_ALL_ON)
+    `uvm_field_int(tgt_id, UVM_ALL_ON)
+    `uvm_field_int(qos, UVM_ALL_ON)
+    `uvm_field_int(resp, UVM_ALL_ON)
+    `uvm_field_int(delay_cycles, UVM_ALL_ON)
+  `uvm_object_utils_end
+
+  function new(string name = "chi_item");
+    super.new(name);
+  endfunction
+endclass

--- a/uvm_chi/agent/chi_monitor.sv
+++ b/uvm_chi/agent/chi_monitor.sv
@@ -1,0 +1,37 @@
+class chi_monitor extends uvm_component;
+  `uvm_component_utils(chi_monitor)
+
+  virtual chi_if vif;
+  uvm_analysis_port #(chi_item) ap;
+
+  function new(string name = "chi_monitor", uvm_component parent = null);
+    super.new(name, parent);
+    ap = new("ap", this);
+  endfunction
+
+  function void build_phase(uvm_phase phase);
+    super.build_phase(phase);
+    if (!uvm_config_db#(virtual chi_if)::get(this, "", "vif", vif)) begin
+      `uvm_fatal(get_type_name(), "Cannot get chi_if vif from config_db")
+    end
+  endfunction
+
+  task run_phase(uvm_phase phase);
+    chi_item tr;
+    forever begin
+      @(posedge vif.clk);
+      if (vif.rst_n && vif.valid && vif.ready) begin
+        tr = chi_item::type_id::create("tr");
+        tr.opcode   = vif.opcode;
+        tr.txn_type = vif.txn_type;
+        tr.addr     = vif.addr;
+        tr.data     = vif.data;
+        tr.src_id   = vif.src_id;
+        tr.tgt_id   = vif.tgt_id;
+        tr.qos      = vif.qos;
+        tr.resp     = vif.resp;
+        ap.write(tr);
+      end
+    end
+  endtask
+endclass

--- a/uvm_chi/agent/chi_sequencer.sv
+++ b/uvm_chi/agent/chi_sequencer.sv
@@ -1,0 +1,7 @@
+class chi_sequencer extends uvm_sequencer #(chi_item);
+  `uvm_component_utils(chi_sequencer)
+
+  function new(string name = "chi_sequencer", uvm_component parent = null);
+    super.new(name, parent);
+  endfunction
+endclass

--- a/uvm_chi/env/chi_coverage.sv
+++ b/uvm_chi/env/chi_coverage.sv
@@ -1,0 +1,29 @@
+class chi_coverage extends uvm_component;
+  `uvm_component_utils(chi_coverage)
+
+  uvm_analysis_imp #(chi_item, chi_coverage) analysis_export;
+  chi_item sample_tr;
+
+  covergroup chi_cg;
+    option.per_instance = 1;
+
+    cp_opcode: coverpoint sample_tr.opcode;
+    cp_txn:    coverpoint sample_tr.txn_type;
+    cp_qos:    coverpoint sample_tr.qos { bins legal[] = {[0:15]}; }
+    cp_resp:   coverpoint sample_tr.resp;
+
+    x_opcode_txn: cross cp_opcode, cp_txn;
+    x_txn_resp:   cross cp_txn, cp_resp;
+  endgroup
+
+  function new(string name = "chi_coverage", uvm_component parent = null);
+    super.new(name, parent);
+    analysis_export = new("analysis_export", this);
+    chi_cg = new();
+  endfunction
+
+  function void write(chi_item tr);
+    sample_tr = tr;
+    chi_cg.sample();
+  endfunction
+endclass

--- a/uvm_chi/env/chi_env.sv
+++ b/uvm_chi/env/chi_env.sv
@@ -1,0 +1,24 @@
+class chi_env extends uvm_env;
+  `uvm_component_utils(chi_env)
+
+  chi_agent      req_agent;
+  chi_scoreboard scb;
+  chi_coverage   cov;
+
+  function new(string name = "chi_env", uvm_component parent = null);
+    super.new(name, parent);
+  endfunction
+
+  function void build_phase(uvm_phase phase);
+    super.build_phase(phase);
+    req_agent = chi_agent::type_id::create("req_agent", this);
+    scb       = chi_scoreboard::type_id::create("scb", this);
+    cov       = chi_coverage::type_id::create("cov", this);
+  endfunction
+
+  function void connect_phase(uvm_phase phase);
+    super.connect_phase(phase);
+    req_agent.mon.ap.connect(scb.analysis_export);
+    req_agent.mon.ap.connect(cov.analysis_export);
+  endfunction
+endclass

--- a/uvm_chi/env/chi_scoreboard.sv
+++ b/uvm_chi/env/chi_scoreboard.sv
@@ -1,0 +1,28 @@
+class chi_scoreboard extends uvm_component;
+  `uvm_component_utils(chi_scoreboard)
+
+  uvm_analysis_imp #(chi_item, chi_scoreboard) analysis_export;
+  int unsigned total_txn;
+
+  function new(string name = "chi_scoreboard", uvm_component parent = null);
+    super.new(name, parent);
+    analysis_export = new("analysis_export", this);
+  endfunction
+
+  function void write(chi_item tr);
+    total_txn++;
+
+    if (tr.addr[5:0] != 6'b0)
+      `uvm_error(get_type_name(), $sformatf("Address not cacheline aligned: %h", tr.addr))
+
+    if (!(tr.qos inside {[0:15]}))
+      `uvm_error(get_type_name(), $sformatf("QoS out-of-range: %0d", tr.qos))
+
+    if (tr.src_id == tr.tgt_id)
+      `uvm_warning(get_type_name(), "src_id == tgt_id, check routing scenario")
+  endfunction
+
+  function void report_phase(uvm_phase phase);
+    `uvm_info(get_type_name(), $sformatf("Total observed CHI txns: %0d", total_txn), UVM_LOW)
+  endfunction
+endclass

--- a/uvm_chi/seq/chi_basic_seq.sv
+++ b/uvm_chi/seq/chi_basic_seq.sv
@@ -1,0 +1,50 @@
+class chi_basic_seq extends uvm_sequence #(chi_item);
+  `uvm_object_utils(chi_basic_seq)
+
+  rand int unsigned num_items;
+  constraint c_num { num_items inside {[100:300]}; }
+
+  function new(string name = "chi_basic_seq");
+    super.new(name);
+  endfunction
+
+  task body();
+    chi_item req;
+    repeat(num_items) begin
+      req = chi_item::type_id::create("req");
+      start_item(req);
+      if (!req.randomize() with {
+          opcode inside {8'h01, 8'h02, 8'h10, 8'h11};
+          txn_type inside {[0:8]};
+          resp inside {[0:3]};
+        }) begin
+        `uvm_error(get_type_name(), "randomize failed for chi_basic_seq item")
+      end
+      finish_item(req);
+    end
+  endtask
+endclass
+
+class chi_corner_seq extends uvm_sequence #(chi_item);
+  `uvm_object_utils(chi_corner_seq)
+
+  function new(string name = "chi_corner_seq");
+    super.new(name);
+  endfunction
+
+  task body();
+    chi_item req;
+    repeat(64) begin
+      req = chi_item::type_id::create("corner_req");
+      start_item(req);
+      if (!req.randomize() with {
+          opcode inside {8'hFF, 8'h00, 8'h7F};
+          qos inside {0, 1, 14, 15};
+          delay_cycles inside {[0:2]};
+        }) begin
+        `uvm_error(get_type_name(), "randomize failed for chi_corner_seq item")
+      end
+      finish_item(req);
+    end
+  endtask
+endclass

--- a/uvm_chi/tb/chi_if.sv
+++ b/uvm_chi/tb/chi_if.sv
@@ -1,0 +1,22 @@
+interface chi_if(input logic clk, input logic rst_n);
+  logic         valid;
+  logic         ready;
+  logic [7:0]   opcode;
+  logic [3:0]   txn_type;
+  logic [47:0]  addr;
+  logic [255:0] data;
+  logic [15:0]  src_id;
+  logic [15:0]  tgt_id;
+  logic [7:0]   qos;
+  logic [3:0]   resp;
+
+  modport tx_mp (
+    input  clk, rst_n, ready,
+    output valid, opcode, txn_type, addr, data, src_id, tgt_id, qos, resp
+  );
+
+  modport rx_mp (
+    input clk, rst_n, valid, opcode, txn_type, addr, data, src_id, tgt_id, qos, resp,
+    output ready
+  );
+endinterface

--- a/uvm_chi/tb/chi_pkg.sv
+++ b/uvm_chi/tb/chi_pkg.sv
@@ -1,0 +1,18 @@
+package chi_pkg;
+  import uvm_pkg::*;
+  `include "uvm_macros.svh"
+
+  `include "agent/chi_item.sv"
+  `include "agent/chi_sequencer.sv"
+  `include "agent/chi_driver.sv"
+  `include "agent/chi_monitor.sv"
+  `include "agent/chi_agent.sv"
+
+  `include "env/chi_scoreboard.sv"
+  `include "env/chi_coverage.sv"
+  `include "env/chi_env.sv"
+
+  `include "seq/chi_basic_seq.sv"
+
+  `include "tb/chi_test.sv"
+endpackage

--- a/uvm_chi/tb/chi_test.sv
+++ b/uvm_chi/tb/chi_test.sv
@@ -1,0 +1,38 @@
+class chi_base_test extends uvm_test;
+  `uvm_component_utils(chi_base_test)
+
+  chi_env env;
+
+  function new(string name = "chi_base_test", uvm_component parent = null);
+    super.new(name, parent);
+  endfunction
+
+  function void build_phase(uvm_phase phase);
+    super.build_phase(phase);
+    env = chi_env::type_id::create("env", this);
+  endfunction
+endclass
+
+class chi_full_func_test extends chi_base_test;
+  `uvm_component_utils(chi_full_func_test)
+
+  function new(string name = "chi_full_func_test", uvm_component parent = null);
+    super.new(name, parent);
+  endfunction
+
+  task run_phase(uvm_phase phase);
+    chi_basic_seq  basic_seq;
+    chi_corner_seq corner_seq;
+
+    phase.raise_objection(this);
+
+    basic_seq = chi_basic_seq::type_id::create("basic_seq");
+    corner_seq = chi_corner_seq::type_id::create("corner_seq");
+
+    basic_seq.start(env.req_agent.sqr);
+    corner_seq.start(env.req_agent.sqr);
+
+    #100ns;
+    phase.drop_objection(this);
+  endtask
+endclass

--- a/uvm_chi/tb/top.sv
+++ b/uvm_chi/tb/top.sv
@@ -1,0 +1,25 @@
+`timescale 1ns/1ps
+
+module top;
+  import uvm_pkg::*;
+  import chi_pkg::*;
+
+  logic clk;
+  logic rst_n;
+
+  chi_if chi_vif(.clk(clk), .rst_n(rst_n));
+
+  always #5 clk = ~clk;
+
+  initial begin
+    clk = 0;
+    rst_n = 0;
+    repeat(10) @(posedge clk);
+    rst_n = 1;
+  end
+
+  initial begin
+    uvm_config_db#(virtual chi_if)::set(null, "*", "vif", chi_vif);
+    run_test("chi_full_func_test");
+  end
+endmodule


### PR DESCRIPTION
### Motivation
- 提供一个可扩展的 UVM 验证骨架，用作落地 CHI 协议“全功能验证”平台的起点（激励/监测/检查/覆盖/场景组织）。
- 在不依赖项目特定细节的前提下实现事务建模、握手驱动、被动观测、scoreboard 与功能覆盖，以便后续扩展到多通道与参考模型。
- 为快速回归与扩展提供统一的打包（`chi_pkg`）与示例顶层运行脚本，降低集成成本。

### Description
- 新增简化 CHI virtual interface `uvm_chi/tb/chi_if.sv` 用于 `valid/ready` 握手驱动与采样。 
- 新增事务与激励栈：`uvm_chi/agent/chi_item.sv`（事务与约束）、`chi_sequencer.sv`、`chi_driver.sv`（drive via `chi_if`）、`chi_monitor.sv`（analysis port）与 `chi_agent.sv`（agent 组装）。
- 新增环境组件：`uvm_chi/env/chi_scoreboard.sv`（基础一致性检查）与 `uvm_chi/env/chi_coverage.sv`（功能覆盖与 cross coverage），以及 `uvm_chi/env/chi_env.sv`（env 组装与连接）。
- 新增序列与测试用例：`uvm_chi/seq/chi_basic_seq.sv`（随机 + corner 序列）与 `uvm_chi/tb/chi_test.sv`（`chi_full_func_test`），并添加仿真顶层 `uvm_chi/tb/top.sv` 与包文件 `uvm_chi/tb/chi_pkg.sv`，同时更新 `README.md` 说明框架结构与扩展路线。 

### Testing
- 执行 `git status --short && rg --files uvm_chi` 验证文件布局，命令返回成功并列出新增文件。 
- 执行 `git commit -m "Add UVM CHI verification framework skeleton"` 提交变更，提交操作成功。 
- 使用 `nl -ba` 列出并检查关键文件内容以确认实现要点（命令执行成功）。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a533488d688330a5af6d89bec6d465)